### PR TITLE
Update python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,19 +1,6 @@
-# This workflow will upload a Python Package to PyPI when a release is created
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: Upload Python Package
-
-on:
-  release:
-    types: [published]
-
-permissions:
-  contents: read
+on: push
 
 jobs:
   build:
@@ -28,7 +15,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
-    
     - name: Install pypa/build
       run: >-
         python3 -m
@@ -42,6 +28,28 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyneon  # Replace <package-name> with your PyPI project name
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI


### PR DESCRIPTION
I have updated the publishing workflow to index the package on pypi. With the current implementation, publishing occurs as follows:
- On each push, the package will be republished to testpypi
- On each release, the package will be published on pypi

For the workflow to work, make sure to create an account with [pypi ](https://pypi.org/account/register/)and [testpypi](https://test.pypi.org/account/register/). Once you have done so, setup the TrustedPublishing thingy on both [pypi ](https://pypi.org/manage/account/publishing/)and [testpypi]( https://test.pypi.org/manage/account/publishing/). 

Make sure to enter the same name as your package name from your project.toml file under PyPI Project Name. Don't change anything to Environment Name. 

Once you have followed these steps, the actions should execute without any issues. Maybe we can then decide to remove the publishing to testpypi for each push